### PR TITLE
Data import work around fix for Spatialite lack of '.distance(...)' support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 *.egg-info
 build
 dist
+cities/data
+
+# WebDAV file system cache
+.DAV/
+


### PR DESCRIPTION
Implemented a work around using (the existing msql code) for handling Spatialite not being able to do '.distance(...)' query operations on SRID 4236 - ValueError: SQLite does not support linear distance calculations on geodetic coordinate systems. See more: https://github.com/coderholic/django-cities/issues/49 
