### PR TITLE
cities.plugin.reset_queries.Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ CITIES_POSTAL_CODES = ['US', 'CA']
 # List of plugins to process data during import
 CITIES_PLUGINS = [
     'cities.plugin.postal_code_ca.Plugin',  # Canada postal codes need region codes remapped to match geonames
+    'cities.plugin.reset_queries.Plugin',  # plugin that helps to reduce memory usage when importing large datasets (e.g. "allCountries.zip")
 ]
 ```
 

--- a/cities/plugin/reset_queries.py
+++ b/cities/plugin/reset_queries.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+"""Call django.db.reset_queries randomly. Default chance is 0.000002 (0.0002%).
+
+This plugin may be useful when processing all geonames database.
+To process all geonames database and include cities that do not specify population
+or when their population is less than 1000 people use following settings:
+
+CITIES_FILES = {
+    'city': {
+       'filename': 'allCountries.zip',
+       'urls':     ['http://download.geonames.org/export/dump/'+'{filename}']
+    },
+}
+
+Settings variable CITIES_PLUGINS_RESET_QUERIES_CHANCE may be used to override
+default chance:
+
+CITIES_PLUGINS_RESET_QUERIES_CHANCE = 1.0 / 1000000
+
+"""
+
+import random
+
+from ..conf import *
+
+from django.db import reset_queries
+from django.conf import settings
+
+reset_chance = getattr(settings, 'CITIES_PLUGINS_RESET_QUERIES_CHANCE', 0.000002)
+
+
+class Plugin:
+
+    def random_reset(self):
+        if random.random() <= reset_chance:
+            reset_queries()
+
+    def city_post(self, parser, city, item):
+        self.random_reset()
+
+    def district_post(self, parser, district, item):
+        self.random_reset()


### PR DESCRIPTION
added ``cities.plugin.reset_queries.Plugin`` that calls reset_queries randomly (default chance is 0.000002 per imported city or district). This plugin may be useful when processing all geonames database ('allCountries.zip')