### PR TITLE
Multiple data files in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ CITIES_FILES = {
     },
 }
 
+# Alternatively you can specify multiple filenames to process:
+CITIES_FILES = {
+    'city': {
+       'filenames': ["US.zip", "GB.zip", ]
+       'urls':     ['http://download.geonames.org/export/dump/'+'{filename}']
+    },
+}
+
 # Localized names will be imported for all ISO 639-1 locale codes below.
 # 'und' is undetermined language data (most alternate names are missing a lang tag).
 # See download.geonames.org/export/dump/iso-languagecodes.txt

--- a/cities/conf.py
+++ b/cities/conf.py
@@ -1,6 +1,7 @@
 from importlib import import_module
 from collections import defaultdict
 from django.conf import settings as django_settings
+from django.core.exceptions import ImproperlyConfigured
     
 __all__ = [
     'city_types','district_types',
@@ -189,7 +190,13 @@ def create_settings():
     res.files = files.copy()
     if hasattr(django_settings, "CITIES_FILES"):
         for key in django_settings.CITIES_FILES.keys():
+            if 'filenames' in django_settings.CITIES_FILES[key] and 'filename' in django_settings.CITIES_FILES[key]:
+                raise ImproperlyConfigured(
+                    "Only one key should be specified for '%s': 'filename' of 'filenames'. Both specified instead" % key
+                )
             res.files[key].update(django_settings.CITIES_FILES[key])
+            if 'filenames' in django_settings.CITIES_FILES[key]:
+                del res.files[key]['filename']
 
     if hasattr(django_settings, "CITIES_LOCALES"):
         locales = django_settings.CITIES_LOCALES[:]


### PR DESCRIPTION
This will allow to specify multiple files to import. For example we can import several specific countries with one config:

```python
# django-cities
CITIES_FILES = {
    'city': {
       'filenames': [
            'AG.zip', 'AU.zip', 'BB.zip', 'BS.zip', 'BW.zip', 'BZ.zip', 'CA.zip',
            'CM.zip', 'DM.zip', 'ER.zip', 'FJ.zip', 'FM.zip', 'GB.zip', 'GD.zip',
            'GH.zip', 'GM.zip', 'GY.zip', 'IE.zip', 'IN.zip', 'JM.zip', 'KE.zip',
            'KI.zip', 'KN.zip', 'LC.zip', 'LR.zip', 'LS.zip', 'MH.zip', 'MT.zip',
            'MU.zip', 'MW.zip', 'NA.zip', 'NG.zip', 'NR.zip', 'NZ.zip', 'PG.zip',
            'PH.zip', 'PK.zip', 'PW.zip', 'RW.zip', 'SB.zip', 'SC.zip', 'SD.zip',
            'SG.zip', 'SL.zip', 'SS.zip', 'SZ.zip', 'TO.zip', 'TT.zip', 'TZ.zip',
            'UG.zip', 'US.zip', 'VC.zip', 'VU.zip', 'WS.zip', 'ZA.zip', 'ZM.zip',
            'ZW.zip'
        ],
       'urls': ['http://download.geonames.org/export/dump/'+'{filename}']
    },
}
```