### PR TITLE
Implemented "nearest_to" method for Place managers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build
 dist
 cities/data
 
+#PyCharm
+.idea/
+
 # WebDAV file system cache
 .DAV/
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name='django-cities',
-    version='0.4.1',
+    version='0.4.2',
     description='Place models and worldwide place data for Django',
     author='Ben Dowling',
     author_email='ben.m.dowling@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name='django-cities',
-    version='0.4.2',
+    version='0.4.2.1',
     description='Place models and worldwide place data for Django',
     author='Ben Dowling',
     author_email='ben.m.dowling@gmail.com',


### PR DESCRIPTION
This allows any Place model to ask its manager (assuming it has a location field) if a particular Point (long/lat) is within a certain number of miles of a known Place of that type in the database.  

Example.  I know I have a long/lat of "-96.8028" and "32.7791".  I want to find the closest City within 10 miles of that Point.

``` python
my_point = Point(-96.8028, 32.7791)
miles_within = 10
closest_city = City.objects.nearest_to(my_point, miles_within)
""" :type : cities.models.City """
if closest_city:
    print "Closest city is {city}.".format(city=closest_city)
else:
    print "No cities in the database within {miles} miles of {pnt}".format(miles=miles_within, pnt=my_point)
```

This is implemented on a new PlaceManager which all Places will get by default.  This function requires a location field, so if a Place does not have a location field then a log message will inform on the problem.  If a location-less Place wants this functionality, and they have a foreign field that DOES have a location, they can implement their own manager with a nearest_to function and expose that relationship themselves.  Additional functionality could also attempt to discover a relationship of that sort automatically.

If this is good, I can update the pull request to have a more appropriate version in the setup.py.  I change it to 0.4.2.1 to be able to differentiate in my requirements to pull only from my personal repo.