### PR TITLE
Add tqdm progress bars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(
     author_email='ben.m.dowling@gmail.com',
     url='https://github.com/coderholic/django-cities',
     packages=find_packages(exclude=['example']),
+    install_requires=[
+        'tqdm',
+    ],
     include_package_data=True,
     zip_safe=False,
     long_description=read('README.md'),

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,14 @@ from setuptools import setup, find_packages
 import codecs
 import os
 
-# Utility function to read the README file.
-# Used for the long_description. It's nice, because now 1) we have a top level
-# README file and 2) it's easier to type in the README file than to put a raw
-# string in below ...
+
 def read(fname):
+    """
+    Utility function to read the README file.
+    Used for the long_description. It's nice, because now (1) we have a top level
+    README file and (2) it's easier to type in the README file than to put a raw
+    string in below ...
+    """
     return codecs.open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
 
 setup(
@@ -20,22 +23,21 @@ setup(
     include_package_data=True,
     zip_safe=False,
     long_description=read('README.md'),
-    license = "MIT",
-    keywords = "django cities countries regions postal codes geonames",
-    classifiers = [
-    "Development Status :: 4 - Beta",
-    "Environment :: Web Environment",
-    "Framework :: Django",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.4",
-    "Topic :: Internet :: WWW/HTTP",
-    "Topic :: Software Development :: Libraries :: Python Modules",
+    license="MIT",
+    keywords="django cities countries regions postal codes geonames",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Topic :: Internet :: WWW/HTTP",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )
-


### PR DESCRIPTION
Use [tqdm](https://github.com/tqdm/tqdm) to show progress bars when performing long operations, like importing each type of data and flushing alternative names for each model.

Also includes PEP-8 fixes for touched files.

The weird

```python
data = self.get_data('...')

total = sum(1 for _ in data)

data = self.get_data('...')
```

is due to the fact that `get_data()` returns a generator instead of a list, so by the time the total is calculated the generator is reading the end of the file (so it must be reset). The `get_data()` function can be updated to calculate the `total` itself and return a `(total, <generator>)` tuple instead, which would make the syntax much more readable and prevent the generator from being created twice during every import. I left this change out to ease review of this PR, and I'll probably fix this in a future PR if nobody else gets to it first.