### PR TITLE
make script support arguments management of django 1.10

### DIFF
--- a/cities/management/commands/cities.py
+++ b/cities/management/commands/cities.py
@@ -63,24 +63,49 @@ class Command(BaseCommand):
         data_dir = os.path.join(app_dir, 'data')
     logger = logging.getLogger(LOGGER_NAME)
 
-    option_list = getattr(BaseCommand, 'option_list', ()) + (
-        make_option(
+    if django.VERSION < (1, 8):
+        option_list = getattr(BaseCommand, 'option_list', ()) + (
+            make_option(
+                '--force',
+                action='store_true',
+                default=False,
+                help='Import even if files are up-to-date.'),
+            make_option(
+                '--import',
+                metavar="DATA_TYPES",
+                default='all',
+                help='Selectively import data. Comma separated list of data ' +
+                     'types: ' + str(import_opts).replace("'", '')),
+            make_option(
+                '--flush',
+                metavar="DATA_TYPES",
+                default='',
+                help="Selectively flush data. Comma separated list of data types."),
+        )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--force',
             action='store_true',
             default=False,
-            help='Import even if files are up-to-date.'),
-        make_option(
+            dest="force",
+            help='Import even if files are up-to-date.'
+        )
+        parser.add_argument(
             '--import',
             metavar="DATA_TYPES",
             default='all',
+            dest="import",
             help='Selectively import data. Comma separated list of data ' +
-                 'types: ' + str(import_opts).replace("'", '')),
-        make_option(
+                 'types: ' + str(import_opts).replace("'", '')
+        )
+        parser.add_argument(
             '--flush',
             metavar="DATA_TYPES",
             default='',
-            help="Selectively flush data. Comma separated list of data types."),
-    )
+            dest="flush",
+            help="Selectively flush data. Comma separated list of data types."
+        )
 
     @_transact
     def handle(self, *args, **options):

--- a/cities/plugin/postal_code_ca.py
+++ b/cities/plugin/postal_code_ca.py
@@ -1,5 +1,3 @@
-from ..conf import *
-
 code_map = {
     'AB': '01',
     'BC': '02',

--- a/cities/plugin/reset_queries.py
+++ b/cities/plugin/reset_queries.py
@@ -22,8 +22,6 @@ CITIES_PLUGINS_RESET_QUERIES_CHANCE = 1.0 / 1000000
 
 import random
 
-from ..conf import *
-
 from django.db import reset_queries
 from django.conf import settings
 


### PR DESCRIPTION
As pointed out by @dpmontero [here](https://github.com/coderholic/django-cities/issues/129#issuecomment-246965066), the extension does not support the add_arguments way of regestering arguments of django 1.10, so importing data doesn't work, which makes it useless. This PR add the support of this new feature. It still support the old way this was done for django 1.7 and lesser thanks to a test on the django version.

Also on my environment, the import in the plugins files failed. I removed them since no settings seemed to be used in the files.