### PR TITLE
fix of an importation bug in alternate names related to boolean management

### DIFF
--- a/cities/management/commands/cities.py
+++ b/cities/management/commands/cities.py
@@ -610,8 +610,8 @@ class Command(BaseCommand):
             alt = AlternativeName()
             alt.id = int(item['nameid'])
             alt.name = item['name']
-            alt.is_preferred = item['isPreferred']
-            alt.is_short = item['isShort']
+            alt.is_preferred = bool(item['isPreferred'])
+            alt.is_short = bool(item['isShort'])
             alt.language = locale
 
             if not self.call_hook('alt_name_post', alt, item):


### PR DESCRIPTION
As described [here](https://github.com/coderholic/django-cities/issues/130), the boolean flags of the alternate name model raise exceptions when value is an empty string. I tried to reinstall, but it didn't fix the issue for me. This PR simply cast the flags value to ensure a boolean is provided to the model.