### PR TITLE
Import all postal codes

### DIFF
--- a/cities/conf.py
+++ b/cities/conf.py
@@ -245,7 +245,7 @@ def create_settings():
     if hasattr(django_settings, "CITIES_POSTAL_CODES"):
         res.postal_codes = set([e.upper() for e in django_settings.CITIES_POSTAL_CODES])
     else:
-        res.postal_codes = set()
+        res.postal_codes = set(['ALL'])
 
     return res
 


### PR DESCRIPTION
Progress bar shows postal codes being imported but they are not really imported because of this. Another alternative is to be more explicit in the documentation, but I think it is better to import "all" when you run: 
```
./manage.py cities --import all
```