### PR TITLE
Remove slug from PostalCode

### DIFF
--- a/cities/management/commands/cities.py
+++ b/cities/management/commands/cities.py
@@ -553,7 +553,6 @@ class Command(BaseCommand):
                 district.code = item['admin3Code']
             except AttributeError:
                 pass
-            district.slug = slugify(district.name_std)
             district.location = Point(float(item['longitude']), float(item['latitude']))
             district.population = int(item['population'])
 

--- a/cities/management/commands/cities.py
+++ b/cities/management/commands/cities.py
@@ -50,7 +50,7 @@ except ImportError:
 from ...conf import (city_types, district_types, import_opts, import_opts_all,
                      HookException, settings, ALTERNATIVE_NAME_TYPES,
                      CONTINENT_DATA, CURRENCY_SYMBOLS, IGNORE_EMPTY_REGIONS,
-                     INCLUDE_AIRPORT_CODES, NO_LONGER_EXISTENT_COUNTRY_CODES)
+                     INCLUDE_AIRPORT_CODES, NO_LONGER_EXISTENT_COUNTRY_CODES, VALIDATE_POSTAL_CODES)
 from ...models import (Region, Subregion, District, PostalCode, AlternativeName)
 from ...util import geo_distance
 

--- a/cities/migrations/0001_initial.py
+++ b/cities/migrations/0001_initial.py
@@ -92,7 +92,6 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=200, verbose_name='ascii name', db_index=True)),
-                ('slug', models.CharField(max_length=200)),
                 ('code', models.CharField(max_length=20)),
                 ('location', django.contrib.gis.db.models.fields.PointField(srid=4326)),
                 ('region_name', models.CharField(max_length=100, db_index=True)),

--- a/cities/migrations/0001_initial.py
+++ b/cities/migrations/0001_initial.py
@@ -76,7 +76,6 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=200, verbose_name='ascii name', db_index=True)),
-                ('slug', models.CharField(max_length=200)),
                 ('name_std', models.CharField(max_length=200, verbose_name='standard name', db_index=True)),
                 ('location', django.contrib.gis.db.models.fields.PointField(srid=4326)),
                 ('population', models.IntegerField()),

--- a/cities/migrations/0009_add_slug_fields_to_models.py
+++ b/cities/migrations/0009_add_slug_fields_to_models.py
@@ -39,11 +39,6 @@ class Migration(migrations.Migration):
             field=models.CharField(max_length=255, unique=True),
         ),
         migrations.AlterField(
-            model_name='postalcode',
-            name='slug',
-            field=models.CharField(max_length=255, unique=True),
-        ),
-        migrations.AlterField(
             model_name='region',
             name='slug',
             field=models.CharField(max_length=255, unique=True),

--- a/cities/migrations/0009_add_slug_fields_to_models.py
+++ b/cities/migrations/0009_add_slug_fields_to_models.py
@@ -34,11 +34,6 @@ class Migration(migrations.Migration):
             field=models.CharField(max_length=255, unique=True),
         ),
         migrations.AlterField(
-            model_name='district',
-            name='slug',
-            field=models.CharField(max_length=255, unique=True),
-        ),
-        migrations.AlterField(
             model_name='region',
             name='slug',
             field=models.CharField(max_length=255, unique=True),

--- a/cities/models.py
+++ b/cities/models.py
@@ -1,5 +1,4 @@
 import sys
-import itertools
 
 try:
     from django.utils.encoding import force_unicode as force_text

--- a/cities/models.py
+++ b/cities/models.py
@@ -231,7 +231,7 @@ class AlternativeName(SlugModel):
 
 
 @python_2_unicode_compatible
-class PostalCode(Place, SlugModel):
+class PostalCode(Place):
     code = models.CharField(max_length=20)
     location = models.PointField()
 
@@ -273,20 +273,3 @@ class PostalCode(Place, SlugModel):
 
     def __str__(self):
         return force_text(self.code)
-
-    def slugify(self):
-        return slugify_func(self, unicode(self.id))
-
-    def save(self, *args, **kwargs):
-        slug = slugify_func(self, self.slugify())
-        for x in itertools.count(1):
-            if self.id:
-                exists = PostalCode.objects.filter(slug=slug).exclude(id=self.id).exists()
-            else:
-                exists = PostalCode.objects.filter(slug=slug).exists()
-            if exists:
-                slug = '%s-%d' % (self.slug, x)
-            else:
-                break
-        self.slug = slug
-        super(SlugModel, self).save(*args, **kwargs)

--- a/cities/models.py
+++ b/cities/models.py
@@ -193,7 +193,7 @@ class City(BaseCity):
         swappable = swapper.swappable_setting('cities', 'City')
 
 
-class District(Place, SlugModel):
+class District(Place):
     name_std = models.CharField(max_length=200, db_index=True, verbose_name="standard name")
     code = models.CharField(blank=True, db_index=True, max_length=200, null=True)
     location = models.PointField()
@@ -203,9 +203,6 @@ class District(Place, SlugModel):
     @property
     def parent(self):
         return self.city
-
-    def slugify(self):
-        return slugify_func(self, unicode(self.id))
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
I could not find the utility of having slug field in postal code model.
Better than this would be to create a new migration