### PR TITLE
Bugfix: SlugModel.save(force_insert=True) tries to double-insert, and crashes

### DIFF
--- a/cities/models.py
+++ b/cities/models.py
@@ -47,6 +47,11 @@ class SlugModel(models.Model):
                 self.slug = 'invalid-{}'.format(''.join(choice(ascii_uppercase + digits) for i in range(20)))
                 super(SlugModel, self).save(*args, **kwargs)
                 self.slug = slugify_func(self, self.slugify())
+
+                # If the 'force_insert' flag was passed, don't pass it again:
+                # doing so will attempt to re-insert with the same primary key,
+                # which will cause an IntegrityError.
+                kwargs.pop('force_insert', None)
                 super(SlugModel, self).save(*args, **kwargs)
         else:
             # This is a performance optimization - we avoid the transaction if

--- a/test_project/test_app/tests/test_models.py
+++ b/test_project/test_app/tests/test_models.py
@@ -1,0 +1,122 @@
+from django.contrib.gis.geos import Point
+from django.test import TestCase
+
+from cities import models
+
+
+class SlugModelTest(object):
+    """
+    Common tests for SlugModel subclasses.
+    """
+
+    def instantiate(self):
+        """
+        Implement this to return a valid instance of the model under test.
+        """
+        raise NotImplementedError
+
+    def test_save(self):
+        instance = self.instantiate()
+        instance.save()
+
+    def test_save_force_insert(self):
+        """
+        Regression test: save() with force_insert=True should work.
+        """
+        instance = self.instantiate()
+        instance.save(force_insert=True)
+
+
+class ContinentTestCase(SlugModelTest, TestCase):
+
+    def instantiate(self):
+        return models.Continent()
+
+
+class CountryTestCase(SlugModelTest, TestCase):
+
+    def instantiate(self):
+        return models.Country(
+            population=0,
+        )
+
+
+class RegionTestCase(SlugModelTest, TestCase):
+
+    def instantiate(self):
+        country = models.Country(
+            population=0
+        )
+        country.save()
+        return models.Region(
+            country=country,
+        )
+
+
+class SubregionTestCase(SlugModelTest, TestCase):
+
+    def instantiate(self):
+        country = models.Country(
+            population=0
+        )
+        country.save()
+        region = models.Region(
+            country=country,
+        )
+        region.save()
+        return models.Subregion(
+            region=region,
+        )
+
+
+class CityTestCase(SlugModelTest, TestCase):
+
+    def instantiate(self):
+        country = models.Country(
+            population=0
+        )
+        country.save()
+        return models.City(
+            country=country,
+            location=Point(0, 0),
+            population=0,
+        )
+
+
+class DistrictTestCase(SlugModelTest, TestCase):
+
+    def instantiate(self):
+        country = models.Country(
+            population=0
+        )
+        country.save()
+        city = models.City(
+            country=country,
+            location=Point(0, 0),
+            population=0,
+        )
+        city.save()
+        return models.District(
+            location=Point(0, 0),
+            population=0,
+            city=city,
+        )
+
+
+class AlternativeNameTestCase(SlugModelTest, TestCase):
+
+    def instantiate(self):
+        return models.AlternativeName()
+
+
+class PostalCodeTestCase(SlugModelTest, TestCase):
+
+    def instantiate(self):
+        country = models.Country(
+            population=0
+        )
+        country.save()
+        return models.PostalCode(
+            location=Point(0, 0),
+            country=country,
+        )


### PR DESCRIPTION
Currently, saving any SlugModel subclass with `save(force_insert=True)` will crash with a database-level IntegrityError.

This happens when using many Django APIs that internally force insertion, such as  `City.objects.create(…)`:

```
django.db.utils.IntegrityError: duplicate key value violates unique constraint "cities_city_pkey"
DETAIL:  Key (id)=(1) already exists.
```

Cause: In the `SlugModel.save()` code that saves the object twice, if the `force_insert` flag was passed, it will also be passed on to the second `save()`  call, even though by this point the object is assumed to be created. This inadvertently forces the existing object to be saved with an `INSERT` instead of an an `UPDATE`, which causes the integrity error above.

This PR clears the `force_insert` flag for the second save, which should avoid the problem.
It also adds some basic regression tests for the affected models: let me know if those look okay.