### PR TITLE
Tox improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,13 @@ The cities manage command has options, see `--help`.  Verbosity is controlled th
         # changes to github and specify commit and repo variables:
         TRAVIS_COMMIT=`git rev-parse HEAD` TRAVIS_REPO_SLUG='github-username/django-cities' POSTGRES_USER=some_username POSTGRES_PASSWORD='password from createuser ste' tox
 
+As an alternative to installing and running PostgreSQL system-wide,
+you can run the tests against a transient Docker instance:
+
+```bash
+docker run --rm -p 127.0.0.1:5432:5432 mdillon/postgis
+```
+
 ### Useful test options:
 
 * `TRAVIS_LOG_LEVEL` - defaults to `INFO`, but set to `DEBUG` to see a (very) large and (very) complete log of the import script

--- a/tox.ini
+++ b/tox.ini
@@ -1,86 +1,16 @@
 [tox]
-envlist = py27-dj1.8, py27-dj1.9, py27-dj1.10, py33-dj1.8, py34-dj1.8, py34-dj1.9, py34-dj1.10, py35-dj1.8, py35-dj1.9, py35-dj1.10, py36-dj1.8, py36-dj1.9, py36-dj1.10
+envlist =
+    py33-dj1.8,
+    py{27,34,35,36}-dj1.{8,9,10}
 
 [testenv]
 commands=python {toxinidir}/test_project/manage.py test test_app --noinput
 passenv = DJANGO_VERSION POSTGRES_USER POSTGRES_PASSWORD TRAVIS_BRANCH
           TRAVIS_COMMIT TRAVIS_LOG_LEVEL TRAVIS_PULL_REQUEST_BRANCH
           TRAVIS_REPO_SLUG
-
-[testenv:py27-dj1.8]
-basepython = python2.7
 deps =
-    django==1.8.14
-    psycopg2==2.6
+    dj1.8: Django ~=1.8.0
+    dj1.9: Django ~=1.9.0
+    dj1.10: Django ~=1.10.0
 
-[testenv:py27-dj1.9]
-basepython = python2.7
-deps =
-    django==1.9.9
-    psycopg2==2.6
-
-[testenv:py27-dj1.10]
-basepython = python2.7
-deps =
-    django==1.10
-    psycopg2==2.6
-
-[testenv:py33-dj1.8]
-basepython = python3.3
-deps =
-    django==1.8.14
-    psycopg2==2.6
-
-[testenv:py34-dj1.8]
-basepython = python3.4
-deps =
-    django==1.8.14
-    psycopg2==2.6
-
-[testenv:py34-dj1.9]
-basepython = python3.4
-deps =
-    django==1.9.9
-    psycopg2==2.6
-
-[testenv:py34-dj1.10]
-basepython = python3.4
-deps =
-    django==1.10
-    psycopg2==2.6
-
-[testenv:py35-dj1.8]
-basepython = python3.5
-deps =
-    django==1.8.14
-    psycopg2==2.6
-
-[testenv:py35-dj1.9]
-basepython = python3.5
-deps =
-    django==1.9.9
-    psycopg2==2.6
-
-[testenv:py35-dj1.10]
-basepython = python3.5
-deps =
-    django==1.10
-    psycopg2==2.6
-
-[testenv:py36-dj1.8]
-basepython = python3.6
-deps =
-    django==1.8.14
-    psycopg2==2.6
-
-[testenv:py36-dj1.9]
-basepython = python3.6
-deps =
-    django==1.9.9
-    psycopg2==2.6
-
-[testenv:py36-dj1.10]
-basepython = python3.6
-deps =
-    django==1.10
     psycopg2==2.6

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ deps =
     dj1.9: Django ~=1.9.0
     dj1.10: Django ~=1.10.0
 
-    psycopg2==2.6
+    psycopg2

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py{27,34,35,36}-dj1.{8,9,10}
 
 [testenv]
-commands=python {toxinidir}/test_project/manage.py test test_app --noinput
+commands=python {toxinidir}/test_project/manage.py test {posargs:test_app} --noinput
 passenv = DJANGO_VERSION POSTGRES_USER POSTGRES_PASSWORD TRAVIS_BRANCH
           TRAVIS_COMMIT TRAVIS_LOG_LEVEL TRAVIS_PULL_REQUEST_BRANCH
           TRAVIS_REPO_SLUG

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py33-dj1.8,
-    py{27,34,35,36}-dj1.{8,9,10}
+    py{27,34,35,36}-dj1.{8,9,10,11}
 
 [testenv]
 commands=python {toxinidir}/test_project/manage.py test {posargs:test_app} --noinput
@@ -12,5 +12,6 @@ deps =
     dj1.8: Django ~=1.8.0
     dj1.9: Django ~=1.9.0
     dj1.10: Django ~=1.10.0
+    dj1.11: Django ~=1.11.0
 
     psycopg2


### PR DESCRIPTION
This simplies the `tox.ini` configuration, adds Django 1.11 to the list of Tox environments, and adds a README instruction for testing against a transient Docker instance of PostgreSQL/PostGIS (rather than installing and running it system-wide).