### PR TITLE
support django 2

### DIFF
--- a/cities/conf.py
+++ b/cities/conf.py
@@ -2,6 +2,8 @@
 
 from importlib import import_module
 from collections import defaultdict
+
+import django
 from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
@@ -363,3 +365,4 @@ SLUGIFY_FUNCTION = getattr(import_module(module_name), function_name)
 # Users who want better postal codes can flip this on (developers of
 # django-cities itself probably will), but most probably won't want to
 VALIDATE_POSTAL_CODES = getattr(django_settings, 'CITIES_VALIDATE_POSTAL_CODES', False)
+DJANGO_VERSION = float('.'.join(map(str, django.VERSION[:2])))

--- a/cities/migrations/0001_initial.py
+++ b/cities/migrations/0001_initial.py
@@ -6,6 +6,8 @@ import django.contrib.gis.db.models.fields
 
 import swapper
 
+from cities.models import SET_NULL_OR_CASCADE
+
 
 class Migration(migrations.Migration):
 
@@ -81,7 +83,7 @@ class Migration(migrations.Migration):
                 ('location', django.contrib.gis.db.models.fields.PointField(srid=4326)),
                 ('population', models.IntegerField()),
                 ('alt_names', models.ManyToManyField(to='cities.AlternativeName')),
-                ('city', models.ForeignKey(to=swapper.get_model_name('cities', 'City'))),
+                ('city', models.ForeignKey(to=swapper.get_model_name('cities', 'City'), on_delete=SET_NULL_OR_CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -99,7 +101,7 @@ class Migration(migrations.Migration):
                 ('subregion_name', models.CharField(max_length=100, db_index=True)),
                 ('district_name', models.CharField(max_length=100, db_index=True)),
                 ('alt_names', models.ManyToManyField(to='cities.AlternativeName')),
-                ('country', models.ForeignKey(related_name='postal_codes', to=swapper.get_model_name('cities', 'Country'))),
+                ('country', models.ForeignKey(related_name='postal_codes', to=swapper.get_model_name('cities', 'Country'), on_delete=SET_NULL_OR_CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -114,7 +116,7 @@ class Migration(migrations.Migration):
                 ('name_std', models.CharField(max_length=200, verbose_name='standard name', db_index=True)),
                 ('code', models.CharField(max_length=200, db_index=True)),
                 ('alt_names', models.ManyToManyField(to='cities.AlternativeName')),
-                ('country', models.ForeignKey(to=swapper.get_model_name('cities', 'Country'))),
+                ('country', models.ForeignKey(to=swapper.get_model_name('cities', 'Country'), on_delete=SET_NULL_OR_CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -129,7 +131,7 @@ class Migration(migrations.Migration):
                 ('name_std', models.CharField(max_length=200, verbose_name='standard name', db_index=True)),
                 ('code', models.CharField(max_length=200, db_index=True)),
                 ('alt_names', models.ManyToManyField(to='cities.AlternativeName')),
-                ('region', models.ForeignKey(to='cities.Region')),
+                ('region', models.ForeignKey(to='cities.Region', on_delete=SET_NULL_OR_CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -138,16 +140,16 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='city',
             name='country',
-            field=models.ForeignKey(to=swapper.get_model_name('cities', 'Country')),
+            field=models.ForeignKey(to=swapper.get_model_name('cities', 'Country'), on_delete=SET_NULL_OR_CASCADE),
         ),
         migrations.AddField(
             model_name='city',
             name='region',
-            field=models.ForeignKey(blank=True, to='cities.Region', null=True),
+            field=models.ForeignKey(blank=True, to='cities.Region', null=True, on_delete=SET_NULL_OR_CASCADE),
         ),
         migrations.AddField(
             model_name='city',
             name='subregion',
-            field=models.ForeignKey(blank=True, to='cities.Subregion', null=True),
+            field=models.ForeignKey(blank=True, to='cities.Subregion', null=True, on_delete=SET_NULL_OR_CASCADE),
         ),
     ]


### PR DESCRIPTION
In Django 2, on_delete argument for ForeignKey is required.
I have created a SET_NULL_OR_CASCADE function which calls SET_NULL when null argument of the field is True, and otherwise calls CASCADE functions.

GeoManager is also deleted from gis models.  [Django docs](https://docs.djangoproject.com/en/2.0/releases/1.9/#deprecated-features-1-9). Since app code doesn't depend on it, I check if django version is below 2, then use GeoManager, else use default Manager.