### PR TITLE
Add default for Country.continent in 0001_initial migration

### DIFF
--- a/cities/migrations/0001_initial.py
+++ b/cities/migrations/0001_initial.py
@@ -61,7 +61,7 @@ class Migration(migrations.Migration):
                 ('currency_name', models.CharField(max_length=50, null=True)),
                 ('languages', models.CharField(max_length=250, null=True)),
                 ('phone', models.CharField(max_length=20)),
-                ('continent', models.CharField(max_length=2)),
+                ('continent', models.CharField(max_length=2, default='')),
                 ('tld', models.CharField(max_length=5)),
                 ('capital', models.CharField(max_length=100)),
                 ('alt_names', models.ManyToManyField(to='cities.AlternativeName')),


### PR DESCRIPTION
Fix for reverting migrations all up to `0001_initial`
https://github.com/coderholic/django-cities/issues/198