### PR TITLE
provide django4 compatibility - Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,34 +6,37 @@ services:
   - postgresql
 
 addons:
-  postgresql: "9.6"
-  # https://gis.stackexchange.com/a/252610
-  # apt:
-  #   packages:
-  #     - postgresql-9.6-postgis-2.3
+  postgresql: "10"
+  apt:
+    packages:
+    - postgresql-10-postgis-2.4
 
 python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
+  - "3.10"
 
 env:
-  - DJANGO_VERSION='Django>=1.11,<1.12'
+  global:
+  - PGPORT=5432
+  - PGUSER=postgres
+  jobs:
   - DJANGO_VERSION='Django>=2.2,<2.3'
-  - DJANGO_VERSION='Django>=3.0,<3.1'
-  - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
+  - DJANGO_VERSION='Django>=3.1,<3.2'
+  - DJANGO_VERSION='Django>=3.2,<4.0'
+  - DJANGO_VERSION='Django>=4.0,<4.1'
 
-matrix:
-  allow_failures:
-    - python: "3.8"
-      env: DJANGO_VERSION='Django>=1.11,<1.12'
-    - env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
-
-before_install:
-  # https://gis.stackexchange.com/a/252610
-  - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" >> /etc/apt/sources.list.d/postgresql.list'
-  - sudo apt-get install --yes postgresql-9.6-postgis-2.4
+jobs:
+  exclude:
+    - python: "3.6"
+      env: DJANGO_VERSION='Django>=4.0,<4.1'
+    - python: "3.7"
+      env: DJANGO_VERSION='Django>=4.0,<4.1'
+    - python: "3.10"
+      env: DJANGO_VERSION='Django>=2.2,<2.3'
+      env: DJANGO_VERSION='Django>=3.1,<3.2'
 
 install:
   - pip install $DJANGO_VERSION

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ django-cities provides you with place related models (eg. Country, Region, City)
 
 This package officially supports all currently supported versions of Python/Django:
 
-|      Python   | 3.6                 | 3.7                   | 3.8                   |
-| :------------ | ------------------- | --------------------- | --------------------- |
-| Django 1.11   | :white_check_mark:  | :white_check_mark:    | :large_blue_circle:   |
-| Django 2.2    | :white_check_mark:  | :white_check_mark:    | :white_check_mark:    |
-| Django 3.0    | :white_check_mark:  | :white_check_mark:    | :white_check_mark:    |
-| Django [master](https://github.com/django/django/archive/master.tar.gz) | :large_blue_circle: | :large_blue_circle: | :large_blue_circle: |
+|      Python   | 3.6                 | 3.7                   | 3.8                   | 3.9                   | 3.10                  |
+| :------------ | ------------------- | --------------------- | --------------------- | --------------------- | --------------------- |
+| Django 2.2    | :white_check_mark:  | :white_check_mark:    | :white_check_mark:    | :white_check_mark:    | :x:                   |
+| Django 3.1    | :white_check_mark:  | :white_check_mark:    | :white_check_mark:    | :white_check_mark:    | :x:                   |
+| Django 3.2    | :white_check_mark:  | :white_check_mark:    | :white_check_mark:    | :white_check_mark:    | :white_check_mark:    |
+| Django 4.0    | :x:                 | :x:                   | :white_check_mark:    | :white_check_mark:    | :white_check_mark:    |
 
 | Key                   |                                                                     |
 | :-------------------: | :------------------------------------------------------------------ |

--- a/cities/conf.py
+++ b/cities/conf.py
@@ -6,7 +6,10 @@ from collections import defaultdict
 import django
 from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import ugettext_lazy as _
+if float('.'.join(map(str, django.VERSION[:2]))) < 3:
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 
 __all__ = [
     'city_types', 'district_types',

--- a/cities/models.py
+++ b/cities/models.py
@@ -1,10 +1,16 @@
 from random import choice
 from string import ascii_uppercase, digits
 
-try:
-    from django.utils.encoding import force_unicode as force_text
-except (NameError, ImportError):
-    from django.utils.encoding import force_text
+from .conf import (ALTERNATIVE_NAME_TYPES, SLUGIFY_FUNCTION, DJANGO_VERSION)
+
+
+if DJANGO_VERSION < 4:
+    try:
+        from django.utils.encoding import force_unicode as force_text
+    except (NameError, ImportError):
+        from django.utils.encoding import force_text
+else:
+    from django.utils.encoding import force_str as force_text
 
 from django.db import transaction
 from django.contrib.gis.db.models import PointField
@@ -14,7 +20,6 @@ from django.contrib.gis.geos import Point
 from model_utils import Choices
 import swapper
 
-from .conf import (ALTERNATIVE_NAME_TYPES, SLUGIFY_FUNCTION, DJANGO_VERSION)
 from .managers import AlternativeNameManager
 from .util import unicode_func
 

--- a/cities/util.py
+++ b/cities/util.py
@@ -4,10 +4,15 @@ import sys
 import unicodedata
 from math import radians, sin, cos, acos
 from django import VERSION as DJANGO_VERSION
-try:
-    from django.utils.encoding import force_unicode as force_text
-except (NameError, ImportError):
-    from django.utils.encoding import force_text
+
+if DJANGO_VERSION < (4, 0):
+    try:
+        from django.utils.encoding import force_unicode as force_text
+    except (NameError, ImportError):
+        from django.utils.encoding import force_text
+else:
+    from django.utils.encoding import force_str as force_text
+
 from django.utils.safestring import mark_safe, SafeText
 
 from .conf import CONTINENT_DATA

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,5 +1,9 @@
 from django import VERSION as DJANGO_VERSION
-from django.conf.urls import include, url
+try:
+    from django.conf.urls import url
+except ImportError:
+    from django.urls import re_path as url
+from django.conf.urls import include
 from django.contrib import admin
 from django.views.generic import ListView
 from cities.models import (Country, Region, City, District, PostalCode)

--- a/test_project/test_app/urls.py
+++ b/test_project/test_app/urls.py
@@ -1,9 +1,12 @@
-from django.conf.urls import url
+try:
+    from django.conf.urls import url
+except ImportError:
+    from django.urls import re_path as url
+
 from django.contrib import admin
 from django.core.exceptions import ImproperlyConfigured
 
 from cities.util import patterns
-
 
 app_name = "test_app"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,20 @@
 [tox]
 envlist =
-    py33-dj1.8,
-    py{27,34,35,36}-dj1.{8,9,10,11}
-    py{34,35,36}-dj2.0
+   {py36,py37,py38,py39}-django22,
+   {py36,py37,py38,py39}-django31,
+   {py36,py37,py38,py39,py310}-django32,
+   {py38,py39,py310}-django40,
 
 [testenv]
 commands=python {toxinidir}/test_project/manage.py test {posargs:test_app} --noinput
 passenv = DJANGO_VERSION POSTGRES_USER POSTGRES_PASSWORD TRAVIS_BRANCH
           TRAVIS_COMMIT TRAVIS_LOG_LEVEL TRAVIS_PULL_REQUEST_BRANCH
           TRAVIS_REPO_SLUG
+
 deps =
-    dj1.8: Django ~=1.8.0
-    dj1.9: Django ~=1.9.0
-    dj1.10: Django ~=1.10.0
-    dj1.11: Django ~=1.11.0
-    dj2.0: Django ~=2.0.0
+    django22: Django>=2.2,<3.0
+    django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<4.0
+    django40: Django>=4.0,<5.0
 
     psycopg2


### PR DESCRIPTION
provide django4 compatibility
Co-authored-by: Frank DiRocco <160608+fdr2@users.noreply.github.com>

Updated travis (running on my fork) to check vs newer pythons
Updated travis to check vs newer Django versions, including 4.0
Needed to upgrade Postgres as Django 4 doesn't support the old Postgres 9.6
Fixed Django imports to work in older and new versions
Updated readme compatibility matrix.